### PR TITLE
correct option() in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ or remove in a paragraph affects all subsequent lines.
 This package is similar to styler, but it styles non-code elements and
 files and it does really just one thing: Making every line at most 80
 characters, or a custom line width you can set with the option
-`stylermd.linewidth`, i.e. `options("stylermd.linewidth", 60)`. It
+`stylermd.line_width`, i.e. `options(stylermd.line_width = 60)`. It
 supports:
 
   - Both adding and removing line breaks for float text, nested


### PR DESCRIPTION
I've removed quotes and added a missing underscore to the `stylermd.line_width` option description in the README.md. Otherwise R will complain (`Error in options("stylermd.linewidth", 60) : invalid argument`) :)

And thank you for the package, it's very useful!